### PR TITLE
Removing dockerfile labels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,6 @@ RUN cp /src/target/*-musl/release/semver ./
 
 FROM scratch
 
-LABEL org.opencontainers.image.source="https://github.com/nicholaschiasson/semver-extra"
-LABEL org.opencontainers.image.description="A Rust implementation of the https://semver.org/ specification"
-LABEL org.opencontainers.image.licenses="MIT"
-
 COPY --from=builder --chmod=755 /build/semver /
 
 ENTRYPOINT [ "/semver" ]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/semver-extra)](https://crates.io/crates/semver-extra)
 
-Extras to help when working with versions, built on top of the [semver](https://crates.io/crates/semver) crate, complete with a CLI tool.
+Helper functions for the [semver](https://crates.io/crates/semver) crate, complete with a CLI tool.
 
 ## CLI
 


### PR DESCRIPTION
Github action for discovering metadata is able to derive these labels from the repository